### PR TITLE
Fix constructor parameter for AccessToken to allow JSON serialization

### DIFF
--- a/src/Harvest/Authentication/AccessToken.cs
+++ b/src/Harvest/Authentication/AccessToken.cs
@@ -10,12 +10,12 @@ public class AccessToken
     /// <summary>
     /// Initializes a new instance of the <see cref="AccessToken"/> class with the specified access token value and expiry information.
     /// </summary>
-    /// <param name="accessToken">The bearer access token value.</param>
+    /// <param name="token">The bearer access token value.</param>
     /// <param name="expiresOn">The time when the provided bearer access token expires.</param>
     /// <param name="refreshToken">The refresh token value.</param>
-    public AccessToken(string accessToken, DateTimeOffset expiresOn = default, string refreshToken = default)
+    public AccessToken(string token, DateTimeOffset expiresOn = default, string refreshToken = default)
     {
-        this.Token = accessToken;
+        this.Token = token;
         this.ExpiresOn = expiresOn;
         this.RefreshToken = refreshToken;
     }

--- a/tests/Harvest.Tests/Tests/AccessTokenTests.cs
+++ b/tests/Harvest.Tests/Tests/AccessTokenTests.cs
@@ -1,0 +1,30 @@
+namespace Harvest.Tests.Tests;
+
+using System;
+using Authentication;
+using Common;
+using Newtonsoft.Json;
+using Shouldly;
+
+[TestFixture]
+public class AccessTokenTests
+{
+    public class WhenSerializingToJson : BaseTestFixture
+    {
+        [Test]
+        public void ShouldDeserializeAllProperties()
+        {
+            // Arrange
+            var accessToken = new AccessToken("token", DateTimeOffset.Now, "refreshToken");
+
+            // Act
+            string serialized = JsonConvert.SerializeObject(accessToken);
+            AccessToken deserialized = JsonConvert.DeserializeObject<AccessToken>(serialized);
+
+            // Assert
+            deserialized.Token.ShouldBe(accessToken.Token);
+            deserialized.ExpiresOn.ShouldBe(accessToken.ExpiresOn);
+            deserialized.RefreshToken.ShouldBe(accessToken.RefreshToken);
+        }
+    }
+}


### PR DESCRIPTION
## Resolves #3 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Minor fix to allow an `AccessToken` to be serialized and deserialized correctly using JSON.NET

## PR checklist

- [x] Have tests been added or updated, run locally, and all pass
- [x] Have code styling rules been run on all new source file changes
- [x] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->