### PR TITLE
Support .NET 4.6.1+

### DIFF
--- a/src/Harvest/Common/Requests/HarvestRequestAdapter.cs
+++ b/src/Harvest/Common/Requests/HarvestRequestAdapter.cs
@@ -58,7 +58,12 @@ public class HarvestRequestAdapter : IDisposable
     {
         HttpResponseMessage response = await this.GetHttpResponseMessageAsync(requestInfo, cancellationToken);
         requestInfo.Content?.Dispose();
-        string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        string responseContent = await response.Content.ReadAsStringAsync(
+#if !NETFRAMEWORK
+            cancellationToken
+#endif
+            );
         if (response.IsSuccessStatusCode)
         {
             return JsonConvert.DeserializeObject<T>(responseContent);
@@ -80,7 +85,11 @@ public class HarvestRequestAdapter : IDisposable
     {
         HttpResponseMessage response = await this.GetHttpResponseMessageAsync(requestInfo, cancellationToken);
         requestInfo.Content?.Dispose();
-        string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        string responseContent = await response.Content.ReadAsStringAsync(
+#if !NETFRAMEWORK
+            cancellationToken
+#endif
+            );
         if (!response.IsSuccessStatusCode)
         {
             throw new HttpRequestException(responseContent);

--- a/src/Harvest/Harvest.csproj
+++ b/src/Harvest/Harvest.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Harvest Time Tracking Client Library</AssemblyTitle>
     <Authors>James Croft</Authors>
     <Version>1.0.0.0</Version>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Harvest</AssemblyName>
     <PackageId>Harvest.Sdk</PackageId>
@@ -36,6 +36,12 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="Tavis.UriTemplates" Version="2.0.0" />
+
   </ItemGroup>
 
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <Reference Include="System.Web" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
It was super simple to add support for .NET 4.x without any significant code changes. 

The only change was not passing in a `cancellationToken` into `ReadAsStringAsync` because it doesn't accept it.